### PR TITLE
Fix for duplicate installation by composer + updated readme with step…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation instructions
 1. Install this component using Composer: 
 
 ```bash
-$ composer require flekto/postcode
+$ composer require postcode-nl/api-magento2-module
 ```
 
 2. Upgrade, compile & clear cache:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ Postcode.nl Account
 A [Postcode.nl account](https://www.postcode.nl/en/services/adresdata/producten-overzicht) is required.
 Testing is free. After testing you can choose to purchase a subscription. 
 
+Installation instructions
+=============
+
+1. Install this component using Composer: 
+
+```bash
+$ composer require flekto/postcode
+```
+
+2. Upgrade, compile & clear cache:
+```bash
+$ php bin/magento setup:upgrade
+$ php bin/magento setup:di:compile
+$ php bin/magento cache:flush
+```
 
 License
 =============

--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,6 @@
     "type": "magento2-module",
     "license": "BSD-2-Clause",
     "homepage": "https://www.postcode.nl/en",
-    "extra": {
-        "map": [
-            [
-                "*",
-                "Flekto/Postcode"
-            ]
-        ]
-    },
     "autoload": {
         "files": [ "registration.php" ],
         "psr-4": {


### PR DESCRIPTION
- Fixed the double installation in vendor + app/code folder. 
- Now only vendor will be used and installation instructions are added in readme.md