### PR TITLE
use interface for generating swagger documentation

### DIFF
--- a/Api/PostcodeModelInterface.php
+++ b/Api/PostcodeModelInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Flekto\Postcode\Api;
+
+use Flekto\Postcode\Helper\ApiClientHelper;
+
+interface PostcodeModelInterface
+{
+
+    /**
+     * @access public
+     * @param string $context
+     * @param string $term
+     * @return string[][]
+     */
+    public function getAddressAutocomplete(string $context, string $term): array;
+
+
+    /**
+     * @access public
+     * @param string $context
+     * @return string[][]
+     */
+    public function getAddressDetails(String $context): array;
+
+
+    /**
+     * @access public
+     * @param string $context
+     * @param string $dispatchCountry
+     * @return string[][]
+     */
+    public function getAddressDetailsCountry(String $context, String $dispatchCountry): array;
+
+
+    /**
+     * @access public
+     * @param string $zipCode
+     * @param string $houseNumber
+     * @return string[][]
+     */
+    public function getNlAddress(String $zipCode, String $houseNumber): array;
+
+}

--- a/Model/PostcodeModel.php
+++ b/Model/PostcodeModel.php
@@ -3,15 +3,13 @@
 namespace Flekto\Postcode\Model;
 
 use Flekto\Postcode\Helper\ApiClientHelper;
+use Flekto\Postcode\Api\PostcodeModelInterface;
 
-class PostcodeModel
+class PostcodeModel implements PostcodeModelInterface
 {
 
     /**
-     * apiClientHelper
-     *
-     * @var mixed
-     * @access protected
+     * @var ApiClientHelper
      */
     protected $apiClientHelper;
 
@@ -20,7 +18,7 @@ class PostcodeModel
      * __construct function.
      *
      * @access public
-     * @param apiClientHelper $apiClientHelper
+     * @param ApiClientHelper $apiClientHelper
      * @return void
      */
     public function __construct(ApiClientHelper $apiClientHelper)
@@ -30,15 +28,9 @@ class PostcodeModel
 
 
     /**
-     * getAddressAutocomplete function.
-     *
-     * @access public
-     * @param $session $context
-     * @param $session $term
-     * @param $session $language
-     * @return Json
+     * @inheritdoc
      */
-    public function getAddressAutocomplete(String $context, String $term)
+    public function getAddressAutocomplete(string $context, string $term): array
     {
         $result = $this->apiClientHelper->getAddressAutocomplete($context, $term);
         return [$result];
@@ -46,13 +38,9 @@ class PostcodeModel
 
 
     /**
-     * getAddressDetails function.
-     *
-     * @access public
-     * @param String $context
-     * @return void
+     * @inheritdoc
      */
-    public function getAddressDetails(String $context)
+    public function getAddressDetails(string $context): array
     {
         $result = $this->apiClientHelper->getAddressDetails($context);
         return [$result];
@@ -60,14 +48,9 @@ class PostcodeModel
 
 
     /**
-     * getAddressDetailsCountry function.
-     *
-     * @access public
-     * @param String $context
-     * @param String $dispatchCountry
-     * @return void
+     * @inheritdoc
      */
-    public function getAddressDetailsCountry(String $context, String $dispatchCountry)
+    public function getAddressDetailsCountry(string $context, string $dispatchCountry): array
     {
         $result = $this->apiClientHelper->getAddressDetails($context, $dispatchCountry);
         return [$result];
@@ -75,14 +58,9 @@ class PostcodeModel
 
 
     /**
-     * getNlAddress function.
-     *
-     * @access public
-     * @param String $zipCode
-     * @param String $houseNumber
-     * @return void
+     * @inheritdoc
      */
-    public function getNlAddress(String $zipCode, String $houseNumber)
+    public function getNlAddress(string $zipCode, string $houseNumber): array
     {
         $result = $this->apiClientHelper->getNlAddress($zipCode, $houseNumber);
         return [$result];

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Flekto\Postcode\Api\PostcodeModelInterface" type="Flekto\Postcode\Model\PostcodeModel" />
+</config>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0"?>
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
     <route url="/V1/flekto/postcode-international/autocomplete/:context/:term" method="GET">
-        <service class="Flekto\Postcode\Model\PostcodeModel" method="getAddressAutocomplete"/>
+        <service class="Flekto\Postcode\Api\PostcodeModelInterface" method="getAddressAutocomplete"/>
         <resources>
            <resource ref="anonymous" />
         </resources>
     </route>
 
     <route url="/V1/flekto/postcode-international/getdetails/:context" method="GET">
-        <service class="Flekto\Postcode\Model\PostcodeModel" method="getAddressDetails"/>
+        <service class="Flekto\Postcode\Api\PostcodeModelInterface" method="getAddressDetails"/>
         <resources>
            <resource ref="anonymous" />
         </resources>
     </route>
 
     <route url="/V1/flekto/postcode-international/getdetails/:context/:dispatchCountry" method="GET">
-        <service class="Flekto\Postcode\Model\PostcodeModel" method="getAddressDetailsCountry"/>
+        <service class="Flekto\Postcode\Api\PostcodeModelInterface" method="getAddressDetailsCountry"/>
         <resources>
            <resource ref="anonymous" />
         </resources>
     </route>
 
     <route url="/V1/flekto/postcode-international/nlzipcode/:zipCode/:houseNumber" method="GET">
-        <service class="Flekto\Postcode\Model\PostcodeModel" method="getNlAddress"/>
+        <service class="Flekto\Postcode\Api\PostcodeModelInterface" method="getNlAddress"/>
         <resources>
            <resource ref="anonymous" />
         </resources>


### PR DESCRIPTION
This pull request fixes #21.
The problem is caused by using a class instead of an interface.

Bugfix has been tested against Magento 2.3.5.