### PR TITLE
Added PHP 8.0 and 8.1 to version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "postcode-nl/api-magento2-module",
     "description": "Postcode.eu International Address API module for Magento 2. Adds autocompletion for addresses in multiple countries using official postal data.",
     "require": {
-      "php": "7.*",
+      "php": "7.* || ^8.0 || ^8.1",
       "magento/module-checkout": "*",
       "magento/module-ui": "*"
     },


### PR DESCRIPTION
```
$ vendor/bin/phpcs -p vendor/postcode-nl/api-magento2-module --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.0 
......................................... 41 / 41 (100%)


Time: 913ms; Memory: 22MB

$ vendor/bin/phpcs -p vendor/postcode-nl/api-magento2-module --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.1
......................................... 41 / 41 (100%)


Time: 953ms; Memory: 22MB
```