### PR TITLE
Initialize postcode & house-number NL fields from checkout-data

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -29,7 +29,7 @@
                                                                     <item name="sortOrder" xsi:type="number">65</item>
                                                                     <item name="children" xsi:type="array">
                                                                         <item name="postcode" xsi:type="array">
-                                                                            <item name="component" xsi:type="string">Flekto_Postcode/js/form/element/postcode</item>
+                                                                            <item name="component" xsi:type="string">Flekto_Postcode/js/form/element/checkout/postcode</item>
                                                                             <item name="label" translate="true" xsi:type="string">Zip/Postal Code</item>
                                                                             <item name="config" xsi:type="array">
                                                                                 <item name="template" xsi:type="string">ui/form/field</item>
@@ -42,7 +42,7 @@
                                                                             <item name="provider" xsi:type="string">checkoutProvider</item>
                                                                         </item>
                                                                         <item name="house_number" xsi:type="array">
-                                                                            <item name="component" xsi:type="string">Flekto_Postcode/js/form/element/house-number</item>
+                                                                            <item name="component" xsi:type="string">Flekto_Postcode/js/form/element/checkout/house-number</item>
                                                                             <item name="label" translate="true" xsi:type="string">House number and addition</item>
                                                                             <item name="config" xsi:type="array">
                                                                                 <item name="template" xsi:type="string">ui/form/field</item>

--- a/view/frontend/web/js/form/element/checkout/house-number.js
+++ b/view/frontend/web/js/form/element/checkout/house-number.js
@@ -1,0 +1,33 @@
+define([
+    'jquery',
+    'Flekto_Postcode/js/form/element/house-number',
+    'Magento_Checkout/js/checkout-data'
+], function ($, houseNumberField, checkoutData) {
+    'use strict';
+
+    return houseNumberField.extend({
+
+        initialize: function () {
+            this._super();
+
+            var shippingAddressData = checkoutData.getShippingAddressFromData();
+            if ($.isEmptyObject(shippingAddressData) ||
+                typeof shippingAddressData.street == 'undefined') {
+                return this;
+            }
+
+            var houseNumberWithAddition = '';
+            if (Object.keys(shippingAddressData.street).length >= 2) {
+                houseNumberWithAddition = houseNumberWithAddition.concat(shippingAddressData.street[1])
+            }
+            if (Object.keys(shippingAddressData.street).length >= 3) {
+                houseNumberWithAddition = houseNumberWithAddition.concat(' ', shippingAddressData.street[2])
+            }
+
+            this.value(houseNumberWithAddition);
+
+            return this;
+        },
+
+    });
+});

--- a/view/frontend/web/js/form/element/checkout/postcode.js
+++ b/view/frontend/web/js/form/element/checkout/postcode.js
@@ -1,0 +1,25 @@
+define([
+    'jquery',
+    'Flekto_Postcode/js/form/element/postcode',
+    'Magento_Checkout/js/checkout-data'
+], function ($, postcodeField, checkoutData) {
+    'use strict';
+
+    return postcodeField.extend({
+
+        initialize: function () {
+            this._super();
+
+            var shippingAddressData = checkoutData.getShippingAddressFromData();
+            if ($.isEmptyObject(shippingAddressData) ||
+                typeof shippingAddressData.postcode == 'undefined') {
+                return this;
+            }
+
+            this.value(shippingAddressData.postcode);
+
+            return this;
+        },
+
+    });
+});


### PR DESCRIPTION
This autofills the postcode & house-number fields when the corresponding data is present in the customer's checkout-data

Fixes postcode-nl/PostcodeNl_Api_Magento2#35