### PR TITLE
[PHP7.4] Fix trailing commas in methods

### DIFF
--- a/Cron/NotifyModuleUpdate.php
+++ b/Cron/NotifyModuleUpdate.php
@@ -24,7 +24,7 @@ class NotifyModuleUpdate
     public function __construct(
         LoggerInterface $logger,
         DataHelper $dataHelper,
-        UpdateNotifier $updateNotifier,
+        UpdateNotifier $updateNotifier
     ) {
         $this->_logger = $logger;
         $this->_dataHelper = $dataHelper;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -53,7 +53,7 @@ class Data extends AbstractHelper
         StoreConfigHelper $storeConfigHelper,
         DirectoryList $dir,
         DriverInterface $filesystem,
-        Curl $curl,
+        Curl $curl
     ) {
         $this->_storeConfigHelper = $storeConfigHelper;
         $this->_dir = $dir;

--- a/Model/UpdateNotification/UpdateNotifier.php
+++ b/Model/UpdateNotification/UpdateNotifier.php
@@ -22,7 +22,7 @@ class UpdateNotifier
      */
     public function __construct(
         NotifierInterface $notifier,
-        UpdateNotificationRepositoryInterface $updateNotification,
+        UpdateNotificationRepositoryInterface $updateNotification
     ) {
         $this->_notifier = $notifier;
         $this->_updateNotification = $updateNotification;


### PR DESCRIPTION
The trialing comma is only supported in method calls since PHP8. 

This package still supports PHP7.4 according to composer.json, so it will break when updated.

It is possible to drop PHP7.4 perhaps. but FIRST a new releases should be tagged that is compatible with PHP7,4, otherwise composer will be stuck on this version and people need to manually downgrade. Also, Magento 2.4.4 is still supported, which supports PHP7.4.