### PR TITLE
Fix TypeError: null is not an object when appending to form-validate element

### DIFF
--- a/view/frontend/templates/customer/address/autofill.phtml
+++ b/view/frontend/templates/customer/address/autofill.phtml
@@ -12,9 +12,14 @@
 </div>
 
 <script>
-    {
-        document.querySelector('#form-validate').appendChild(document.getElementById('block-loader-customer-address'));
-    }
+    document.addEventListener('DOMContentLoaded', () => {
+        const formValidate = document.querySelector('#form-validate');
+        const blockLoader = document.getElementById('block-loader-customer-address');
+        
+        if (formValidate && blockLoader) {
+            formValidate.appendChild(blockLoader);
+        }
+    });
 </script>
 
 <div class="fieldset address-autofill-fieldset" data-bind="scope: 'address_autofill'">


### PR DESCRIPTION
## Description
Fixes a TypeError that occurs when the `#form-validate` element doesn't exist in the DOM when the autofill template tries to append the block loader element.

## Problem
The code was attempting to call `appendChild()` directly on the result of `querySelector('#form-validate')` without checking if the element exists. This caused crashes on the customer address edit page in certain scenarios (e.g., when using Hyvä theme or when the form hasn't been rendered yet).

**Error:**
```
TypeError: null is not an object (evaluating 'document.querySelector('#form-validate').appendChild')
```

## Solution
- Added `DOMContentLoaded` event listener to ensure the DOM is fully loaded before manipulating elements
- Added null checks for both `#form-validate` and `#block-loader-customer-address` elements before attempting the append operation
- Only performs `appendChild()` when both elements exist

## Impact
This is a defensive fix that prevents crashes without changing existing functionality when elements are present.